### PR TITLE
Docker label is now only on master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ properties(
 
 String channel = '#platform-engineering'
 
-node('docker') {
+node('slave') {
   try {
     stage('Checkout') {
       deleteDir()


### PR DESCRIPTION
Use slave so this job doesn't get blocked by all the failing master jobs